### PR TITLE
old C for old Ruby (fix #6)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -542,7 +542,7 @@ class RubySource
     %w[gcc cc].each {|cc_bin|
       File.open("#{prefix}/bin/#{cc_bin}", "w") {|f|
         f.puts "#!/bin/sh"
-        f.puts "#{gcc} -m32 \"$@\""
+        f.puts "#{gcc} -m32 -std=gnu89 \"$@\""
       }
       File.chmod(0755, "#{prefix}/bin/#{cc_bin}")
     }


### PR DESCRIPTION
The build failure was due to our C compiler is too new.  Force it '89 mode.