### PR TITLE
Use Bullseye with multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ RUN dpkg --add-architecture i386 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=0 /build-all-ruby/ /build-all-ruby
-COPY --from=0 /all-ruby/ /all-ruby
 
 WORKDIR /all-ruby
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN rake setup_build
 # rake -j interpret non-numeric argument as number of CPUs plus 3.
 ARG j=numcpu_plus_alpha
 
-COPY versions/1.* versions/2.1* versions/2.2* /all-ruby/versions/
+COPY versions/1.* versions/2.1* versions/2.2* versions/2.3* versions/2.4* versions/2.5* versions/2.6* versions/2.7* versions/3.0* /all-ruby/versions/
 RUN rake -j ${j} all-1.2 all-1.3 all-1.4 all-1.6
 RUN rake -j ${j} all-1.8.6
 RUN rake -j ${j} all-1.8.7
@@ -89,23 +89,11 @@ RUN rake -j ${j} all-1.9.2
 RUN rake -j ${j} all-1.9.3
 RUN rake -j ${j} all-2.1
 RUN rake -j ${j} all-2.2
-
-COPY versions/2.3* /all-ruby/versions/
 RUN rake -j ${j} all-2.3
-
-COPY versions/2.4* /all-ruby/versions/
 RUN rake -j ${j} all-2.4
-
-COPY versions/2.5* /all-ruby/versions/
 RUN rake -j ${j} all-2.5
-
-COPY versions/2.6* /all-ruby/versions/
 RUN rake -j ${j} all-2.6
-
-COPY versions/2.7* /all-ruby/versions/
 RUN rake -j ${j} all-2.7
-
-COPY versions/3.0* /all-ruby/versions/
 RUN rake -j ${j} all-3.0
 
 COPY versions/3.1* /all-ruby/versions/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN rake -j ${j} all-1.1c
 RUN rake -j ${j} all-1.1d
 RUN rake -j ${j} all-1.8
 RUN rake -j ${j} all-1.8.5
+RUN rake -j ${j} all-2.0.0
 
 RUN rm -rf Rakefile versions/ patch/
 RUN rm -rf DIST build/*/log build/*/ruby*/
@@ -99,7 +100,6 @@ RUN rake -j ${j} all-1.9.0
 RUN rake -j ${j} all-1.9.1
 RUN rake -j ${j} all-1.9.2
 RUN rake -j ${j} all-1.9.3
-RUN rake -j ${j} all-2.0.0
 RUN rake -j ${j} all-2.1
 RUN rake -j ${j} all-2.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,13 +80,8 @@ RUN rake setup_build
 ARG j=numcpu_plus_alpha
 
 COPY versions/1.* versions/2.1* versions/2.2* versions/2.3* versions/2.4* versions/2.5* versions/2.6* versions/2.7* versions/3.0* /all-ruby/versions/
-RUN rake -j ${j} all-1.2 all-1.3 all-1.4 all-1.6
-RUN rake -j ${j} all-1.8.6
-RUN rake -j ${j} all-1.8.7
-RUN rake -j ${j} all-1.9.0
-RUN rake -j ${j} all-1.9.1
-RUN rake -j ${j} all-1.9.2
-RUN rake -j ${j} all-1.9.3
+RUN rake -j ${j} all-1.2 all-1.3 all-1.4 all-1.6 all-1.8.6 all-1.8.7
+RUN rake -j ${j} all-1.9.0 all-1.9.1 all-1.9.2 all-1.9.3
 RUN rake -j ${j} all-2.1
 RUN rake -j ${j} all-2.2
 RUN rake -j ${j} all-2.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN dpkg --add-architecture i386 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=0 /build-all-ruby/ /build-all-ruby
+COPY --from=0 /all-ruby/ /all-ruby
 
 WORKDIR /all-ruby
 
@@ -109,6 +110,7 @@ RUN rm -rf DIST build/*/log build/*/ruby*/
 RUN rm -rf build/*/man build/*/share/man build/*/share/doc build/*/share/ri
 RUN rm -f build/*/lib/libruby-static.a
 RUN rm -f build/*/bin/gcc build/*/bin/cc
+
 RUN find /build-all-ruby -type f \( -name ruby -o -name '*.so' \) -exec sh -c 'file $1 | grep -q "not stripped"' - '{}' \; -print0 | xargs -0 strip
 RUN rdfind -makehardlinks true -makeresultsfile false /build-all-ruby
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN rake setup_build
 # rake -j interpret non-numeric argument as number of CPUs plus 3.
 ARG j=numcpu_plus_alpha
 
-COPY versions/0.* versions/1.* versions/2.0.0* versions/2.1* versions/2.2* /all-ruby/versions/
+COPY versions/0.* versions/1.* versions/2.0.0* /all-ruby/versions/
 RUN rake -j ${j} all-0 all-1.0 all-1.1a all-1.1b all-1.1c all-1.1d all-1.8 all-1.8.5
 RUN rake -j ${j} all-2.0.0
 
@@ -79,7 +79,7 @@ RUN rake setup_build
 # rake -j interpret non-numeric argument as number of CPUs plus 3.
 ARG j=numcpu_plus_alpha
 
-COPY versions/0.* versions/1.* versions/2.0.0* versions/2.1* versions/2.2* /all-ruby/versions/
+COPY versions/1.* versions/2.1* versions/2.2* /all-ruby/versions/
 RUN rake -j ${j} all-1.2 all-1.3 all-1.4 all-1.6
 RUN rake -j ${j} all-1.8.6
 RUN rake -j ${j} all-1.8.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ ARG j=numcpu_plus_alpha
 
 COPY versions/1.* versions/2.1* versions/2.2* versions/2.3* versions/2.4* versions/2.5* versions/2.6* versions/2.7* versions/3.0* /all-ruby/versions/
 RUN rake -j ${j} all-1.2 all-1.3 all-1.4 all-1.6 all-1.8.6 all-1.8.7
-RUN rake -j ${j} all-1.9.0 all-1.9.1 all-1.9.2 all-1.9.3
+RUN rake -j ${j} all-1.9.0 all-1.9.1 all-1.9.2
+RUN rake -j ${j} all-1.9.3
 RUN rake -j ${j} all-2.1
 RUN rake -j ${j} all-2.2
 RUN rake -j ${j} all-2.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG os=debian
-ARG version=buster
+ARG version=bullseye
 ARG variant=-slim
 ARG mirror=http://deb.debian.org/debian
-ARG system_ruby=ruby2.5
+ARG system_ruby=ruby2.7
 
 FROM ${os}:${version}${variant}
 ENV DEBIAN_FRONTEND=noninteractive
@@ -119,17 +119,17 @@ RUN dpkg --add-architecture i386 \
   && apt-get update \
   && apt-get install \
       libc6:i386 \
-      libffi6:i386 \
+      libffi7:i386 \
       libgcc1:i386 \
       libgdbm6:i386 \
       libncurses5:i386 \
-      libreadline7:i386 \
+      libreadline8:i386 \
       libssl1.1:i386 \
       zlib1g:i386 \
-      libffi6:amd64 \
+      libffi7:amd64 \
       libgdbm6:amd64 \
       libncurses5:amd64 \
-      libreadline7:amd64 \
+      libreadline8:amd64 \
       libssl1.1:amd64 \
       zlib1g:amd64 \
       gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,6 @@ RUN rm -rf DIST build/*/log build/*/ruby*/
 RUN rm -rf build/*/man build/*/share/man build/*/share/doc build/*/share/ri
 RUN rm -f build/*/lib/libruby-static.a
 RUN rm -f build/*/bin/gcc build/*/bin/cc
-RUN find /build-all-ruby -type f \( -name ruby -o -name '*.so' \) -exec sh -c 'file $1 | grep -q "not stripped"' - '{}' \; -print0 | xargs -0 strip
-RUN rdfind -makehardlinks true -makeresultsfile false /build-all-ruby
 
 FROM ${os}:${version}${variant}
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,21 +89,13 @@ RUN rake -j ${j} all-3.3
 COPY lib/* /all-ruby/lib/
 COPY all-ruby /all-ruby/
 
-#RUN du -s /build-all-ruby
 RUN rm -rf Rakefile versions/ patch/
-#RUN du -s /build-all-ruby
 RUN rm -rf DIST build/*/log build/*/ruby*/
-#RUN du -s /build-all-ruby
 RUN rm -rf build/*/man build/*/share/man build/*/share/doc build/*/share/ri
-#RUN du -s /build-all-ruby
 RUN rm -f build/*/lib/libruby-static.a
-#RUN du -s /build-all-ruby
 RUN rm -f build/*/bin/gcc build/*/bin/cc
-#RUN du -s /build-all-ruby
 RUN find /build-all-ruby -type f \( -name ruby -o -name '*.so' \) -exec sh -c 'file $1 | grep -q "not stripped"' - '{}' \; -print0 | xargs -0 strip
-#RUN du -s /build-all-ruby
 RUN rdfind -makehardlinks true -makeresultsfile false /build-all-ruby
-#RUN du -s /build-all-ruby
 
 FROM ${os}:${version}${variant}
 ARG mirror

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ARG variant=-slim
 ARG mirror=http://deb.debian.org/debian
 ARG system_ruby=ruby2.7
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Build for 0.*, 1.0*, 1.1*, 1.8 and 1.8.5
 FROM debian:buster-slim
 ENV DEBIAN_FRONTEND=noninteractive
@@ -56,6 +54,7 @@ RUN find /build-all-ruby -type f \( -name ruby -o -name '*.so' \) -exec sh -c 'f
 RUN rdfind -makehardlinks true -makeresultsfile false /build-all-ruby
 
 FROM ${os}:${version}${variant}
+ENV DEBIAN_FRONTEND=noninteractive
 ARG mirror
 ARG version
 ARG system_ruby
@@ -143,6 +142,7 @@ RUN find /build-all-ruby -type f \( -name ruby -o -name '*.so' \) -exec sh -c 'f
 RUN rdfind -makehardlinks true -makeresultsfile false /build-all-ruby
 
 FROM ${os}:${version}${variant}
+ENV DEBIAN_FRONTEND=noninteractive
 ARG mirror
 ARG version
 ARG system_ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,7 @@ RUN rake setup_build
 ARG j=numcpu_plus_alpha
 
 COPY versions/0.* versions/1.* versions/2.0.0* versions/2.1* versions/2.2* /all-ruby/versions/
-RUN rake -j ${j} all-0
-RUN rake -j ${j} all-1.0
-RUN rake -j ${j} all-1.1a
-RUN rake -j ${j} all-1.1b
-RUN rake -j ${j} all-1.1c
-RUN rake -j ${j} all-1.1d
-RUN rake -j ${j} all-1.8
-RUN rake -j ${j} all-1.8.5
+RUN rake -j ${j} all-0 all-1.0 all-1.1a all-1.1b all-1.1c all-1.1d all-1.8 all-1.8.5
 RUN rake -j ${j} all-2.0.0
 
 RUN rm -rf Rakefile versions/ patch/
@@ -87,10 +80,7 @@ RUN rake setup_build
 ARG j=numcpu_plus_alpha
 
 COPY versions/0.* versions/1.* versions/2.0.0* versions/2.1* versions/2.2* /all-ruby/versions/
-RUN rake -j ${j} all-1.2
-RUN rake -j ${j} all-1.3
-RUN rake -j ${j} all-1.4
-RUN rake -j ${j} all-1.6
+RUN rake -j ${j} all-1.2 all-1.3 all-1.4 all-1.6
 RUN rake -j ${j} all-1.8.6
 RUN rake -j ${j} all-1.8.7
 RUN rake -j ${j} all-1.9.0

--- a/Rakefile
+++ b/Rakefile
@@ -558,12 +558,13 @@ end
 
 task :setup_build do
   if File.symlink? "build"
-    raise "'build' symlink already exist."
+    puts "'build' symlink already exist."
+  else
+    build_dirname = "../build-all-ruby"
+    Dir.mkdir build_dirname
+    File.symlink build_dirname, "build"
+    puts "symlink created: build -> #{build_dirname}"
   end
-  build_dirname = "../build-all-ruby"
-  Dir.mkdir build_dirname
-  File.symlink build_dirname, "build"
-  puts "symlink created: build -> #{build_dirname}"
 end
 
 multitask :all => RubySource::TABLE.map {|h| h[:version] }.reverse

--- a/Rakefile
+++ b/Rakefile
@@ -561,7 +561,7 @@ task :setup_build do
     puts "'build' symlink already exist."
   else
     build_dirname = "../build-all-ruby"
-    Dir.mkdir build_dirname
+    Dir.mkdir build_dirname unless File.directory? build_dirname
     File.symlink build_dirname, "build"
     puts "symlink created: build -> #{build_dirname}"
   end


### PR DESCRIPTION
`buster` is EOL today. We should replace it to bullseye or bookworm. But I found some issues.

* bullseye can build Ruby 1.2 or later.
* bookworm can build Ruby 3.1 or later.
  * Because bookworm only has OpenSSL 3.x.

I try to build Ruby 0.x to 1.1 with buster and copy them to bullseye image by multi-stage build.