### PR TITLE
some system, alloca() must be void *, not char *

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -300,6 +300,11 @@ class RubySource
     if version_between('0.69', '0.95')
       patch srcdir, 'glob-alloca2'
     end
+    if RbConfig::CONFIG['arch'] =~ /freebsd/
+      if version_between('0.69', '1.1b9_19')
+        patch srcdir, 'glob-voidalloca'
+      end
+    end
     if version_between('0.49', '0.55')
       patch srcdir, 'ruby-errno3'
     elsif version_between('0.60', '0.76')

--- a/patch/glob-voidalloca.diff
+++ b/patch/glob-voidalloca.diff
@@ -1,0 +1,9 @@
+--- glob.c-	2024-03-20 18:41:00.808630000 +0900
++++ glob.c	2024-03-20 18:41:33.134288000 +0900
+@@ -83,5 +83,5 @@
+ #include <alloca.h>
+ #else
+-char *alloca ();
++void *alloca ();
+ #endif
+ #endif


### PR DESCRIPTION
FreeBSDではalloca()の返戻値の型をvoid *にしないとalloca()だと認めてくれなかったためのパッチです。