### PR TITLE
In FreeBSD, extern int sys_nerr causes problem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -364,6 +364,15 @@ class RubySource
     elsif version_between('0.51', '0.76')
       patch srcdir, 'error-error'
     end
+    if RbConfig::CONFIG['arch'] =~ /freebsd/
+      if version_between('0.99.4-961224', '1.0-961225')
+        patch srcdir, 'error-sysnerr'
+      elsif version_between('1.0-971002', '1.4.2')
+        patch srcdir, 'error-sysnerr2'
+      elsif version_between('1.4.3', '1.6.4')
+        patch srcdir, 'error-sysnerr3'
+      end
+    end
     if version_between('0.49', '0.76')
       modify_file("#{build_reldir}/#{srcdir}/io.c") {|content|
         content.gsub!(/->_gptr/, "->_IO_read_ptr")

--- a/patch/error-sysnerr.diff
+++ b/patch/error-sysnerr.diff
@@ -1,0 +1,11 @@
+--- error.c-	2024-03-20 19:28:51.656475000 +0900
++++ error.c	2024-03-20 19:29:47.710252000 +0900
+@@ -380,7 +380,7 @@
+     rb_raise(exc_new(syserr_list[n], buf));
+ }
+ 
+-extern int sys_nerr;
++extern int const sys_nerr;
+ 
+ static void
+ init_syserr()

--- a/patch/error-sysnerr2.diff
+++ b/patch/error-sysnerr2.diff
@@ -1,0 +1,11 @@
+--- error.c-	2024-03-20 14:02:45.691320000 +0900
++++ error.c	2024-03-20 14:04:05.705772000 +0900
+@@ -432,7 +432,7 @@
+ static VALUE *syserr_list;
+ #endif
+ 
+-#ifndef NT
++#if !defined(NT) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(sys_nerr)
+ extern int sys_nerr;
+ #endif
+ 

--- a/patch/error-sysnerr3.diff
+++ b/patch/error-sysnerr3.diff
@@ -1,0 +1,11 @@
+--- error.c-	2001-03-21 17:04:11.000000000 +0900
++++ error.c	2001-09-03 14:20:48.000000000 +0900
+@@ -468,7 +468,7 @@
+ static VALUE *syserr_list;
+ #endif
+ 
+-#if !defined NT && !defined sys_nerr
++#if !defined(NT) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(sys_nerr)
+ extern int sys_nerr;
+ #endif
+ 


### PR DESCRIPTION
FreeBSD では extern int sys_nerr という宣言が問題を起こすのでそれに対するパッチです。